### PR TITLE
Improve build and publish workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,16 +10,30 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+
     - name: Install dependencies
       run: dotnet restore
       working-directory: ./Src
+
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --configuration Release --no-restore -p:ContinuousIntegrationBuild=true
       working-directory: ./Src
+
     - name: Test .NET 4.8
-      run: dotnet test -f net48 --no-restore --verbosity normal
+      run: dotnet test -f net48 --configuration Release --no-restore --no-build --verbosity normal
       working-directory: ./Src
+
     - name: Test .NET 8
-      run: dotnet test -f net8 --no-restore --verbosity normal
+      run: dotnet test -f net8 --configuration Release --no-restore --no-build --verbosity normal
       working-directory: ./Src
+
+    - name: Pack
+      run: dotnet pack --configuration Release --no-restore --no-build -o "../artifacts"
+      working-directory: ./Src
+
+    - name: Publish
+      uses: actions/upload-artifact@v4
+      with:
+        name: packages
+        path: 'artifacts/*.*nupkg'

--- a/Src/Enums.NET/Enums.NET.csproj
+++ b/Src/Enums.NET/Enums.NET.csproj
@@ -26,6 +26,10 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <DebugType>portable</DebugType>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
* ensure proper flags for package
* generate symbols
* package and publish as part of CI flow

Old: https://nuget.info/packages/Enums.NET/5.0.0

Now: 

![image](https://github.com/user-attachments/assets/d43537c0-14e2-4d7b-9851-c40e83e4f2cb)

When uploading to NuGet should also upload the snupkg file.